### PR TITLE
Do not check CSS files with lint-staged pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react-test-renderer": "^18.2.0"
   },
   "lint-staged": {
-    "src/**/*.{js,jsx,ts,tsx,css}": [
+    "src/**/*.{js,jsx,ts,tsx}": [
       "eslint --fix",
       "prettier --write"
     ]


### PR DESCRIPTION
`lint-staged` pre-commit hook was set up to check `.css` files on every commit (in addition to `.js`, `.jsx`, `.ts`, and `.tsx`). ESLint doesn't support linting CSS files, which caused this hook to fail, thus preventing making a commit.

CSS file types are now excluded from this check.