### PR TITLE
Save color scheme

### DIFF
--- a/src/components/ColorScheme/index.tsx
+++ b/src/components/ColorScheme/index.tsx
@@ -7,12 +7,14 @@ type colorSchemeProps = {
   buttonType: 'save' | 'delete';
   colorSchemeData: ColorSchemeType;
   colorSchemeTitle?: string;
+  clickHandler?: Function;
 };
 
 function ColorScheme({
   buttonType,
   colorSchemeData,
   colorSchemeTitle,
+  clickHandler = () => {},
 }: colorSchemeProps) {
   // For some color schemes, fetched color scheme data object contains `count`
   // field with correct number, but the `colors` array contains more colors
@@ -21,7 +23,7 @@ function ColorScheme({
   // to correct length
   const colorQty = Number(colorSchemeData.count);
 
-  const button = <Button type={buttonType} onClick={() => {}} />;
+  const button = <Button type={buttonType} onClick={clickHandler} />;
   const baseColorSwatch = (
     <ColorSwatch
       colorCode={colorSchemeData.seed.hex.value}

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -11,6 +11,14 @@ function Create() {
   const [colorHarmonyRule, setColorHarmonyRule] = useState('monochrome');
   const [colorSchemeData, setColorSchemeData] = useState(colorSchemeSample);
 
+  const saveColorSchemeClickHandler = () => {
+    const baseColorValue = colorSchemeData.seed.hex.clean.toLowerCase();
+    const newColorScheme = {
+      [baseColorValue]: colorSchemeData,
+    };
+    console.log(newColorScheme);
+  };
+
   return (
     <>
       <ColorHarmonyOptions
@@ -22,7 +30,11 @@ function Create() {
           setColorSchemeData(colorSchemeData)
         }
       />
-      <ColorScheme buttonType="save" colorSchemeData={colorSchemeData} />
+      <ColorScheme
+        buttonType="save"
+        colorSchemeData={colorSchemeData}
+        clickHandler={saveColorSchemeClickHandler}
+      />
     </>
   );
 }

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -13,10 +13,19 @@ function Create() {
 
   const saveColorSchemeClickHandler = () => {
     const baseColorValue = colorSchemeData.seed.hex.clean.toLowerCase();
-    const newColorScheme = {
-      [baseColorValue]: colorSchemeData,
+    const colorMode = colorSchemeData.mode;
+    const colorSchemeKey = baseColorValue + '-' + colorMode;
+    const savedColorSchemes = JSON.parse(
+      localStorage.getItem('savedColorSchemes') || '{}'
+    );
+    const newSavedColorSchemes = {
+      ...savedColorSchemes,
+      [colorSchemeKey]: colorSchemeData,
     };
-    console.log(newColorScheme);
+    localStorage.setItem(
+      'savedColorSchemes',
+      JSON.stringify(newSavedColorSchemes)
+    );
   };
 
   return (


### PR DESCRIPTION
The generated color scheme is saved when clicking the `Save Color Scheme` button.

The color scheme data is saved in the local storage object called `savedColorSchemes`. Keys in this object are created by combining the base color's hex value and the selected color mode, e.g. `2196f3-monochrome`, `2df41f-analogic-complement`. The value is the generated color scheme data fetched from [The Color API](https://www.thecolorapi.com/).